### PR TITLE
catch error in message to reject worker call promise

### DIFF
--- a/src/HermesMessenger/index.worker.js
+++ b/src/HermesMessenger/index.worker.js
@@ -57,7 +57,9 @@ class HermesMessenger {
             this.config = event.data;
             this._loadedPromises.forEach(resolve => resolve());
         } else if (event.type === "call") {
-            this._call(event);
+            this._call(event).catch((error) => {
+                this._sendError(event, error);
+            });
         }
     }
 
@@ -94,6 +96,14 @@ class HermesMessenger {
             id: data.id,
             result,
         }, result.transferable);
+    }
+
+    _sendError(data, error) {
+        this._sendEvent({
+            type: "error",
+            id: data.id,
+            error,
+        });
     }
 
     _sendEvent(data, transferable = []) {

--- a/src/HermesWorker/index.js
+++ b/src/HermesWorker/index.js
@@ -224,6 +224,11 @@ class HermesWorker {
 
             this._pendingsCalls[answer.id].resolve(this._hermesSerializers.unserializeArgs(answer.result)[0]);
             delete this._pendingsCalls[answer.id];
+        } else if (answer.type === "error") {
+            if (!this._pendingsCalls[answer.id]) return;
+
+            this._pendingsCalls[answer.id].reject(answer.error);
+            delete this._pendingsCalls[answer.id];
         }
     }
 


### PR DESCRIPTION
If there is an error in some event callback, the call promise is not rejected in worker, and there is a "Uncaught (in promise)" error in the messenger